### PR TITLE
Patch to switch between mailR library and blastula.

### DIFF
--- a/shiny/server/contact_handlers.R
+++ b/shiny/server/contact_handlers.R
@@ -42,30 +42,33 @@ add.contact.handlers <- function(session, input, output)
                 show_modal_spinner(session=session,
                                    text=HTML('<div class="uploading_custom"><h1>Sending message...</h1></div>'),
                                    spin='bounce')
+
+                #JP Converting from mailR to blastula
                 
-                send.mail(
-                    from=email, 
-                    to=CONTACT.EMAILS,
-                    subject=paste0('EndingHIV email from: ', name),
-                    body=paste0(
+                email.body <- paste0(
                         # Keep indented like this for email formatting purposes.
                         'Name: ', name, '
         Email: ', email, '
         Contents: 
-        ', contents),
-                    smtp=list(
-                        host.name="smtp.gmail.com",
-                        port=list(
-                            'ssl'=465,
-                            'tls'=587
-                        )[['tls']],
-                        user.name=Sys.getenv("EMAIL_USERNAME"),
-                        passwd=Sys.getenv("EMAIL_PASSWORD"),
-                        #ssl=T,
-                        tls=T),
-                    # debug=T
-                    authenticate=T, 
-                    send=T)
+        ', contents)
+
+                email.account <- Sys.getenv("EMAIL_USERNAME")
+
+                smtp_send(
+                    email = compose_email(body = email.body),
+                    to = CONTACT.EMAILS,
+                    from = email.account,
+                    subject = paste0('EndingHIV email from: ', name),
+                    credentials = creds_envvar(
+                        user = email.account,
+                        #creds_envvar uses Sys.getenv(pass_envvar) internally
+                        pass_envvar = "EMAIL_PASSWORD",
+                        provider = "gmail",
+                        host = "smtp.gmail.com",
+                        port=465,
+                        use_ssl=T
+                    )
+                )
                 
                 # Warning: Error in : FATAL:  no pg_hba.conf entry for host 
                 # "73.135.116.183", user "jklcmyywfuzgrf", database "d7kjdf34erfuu8", 

--- a/shiny/source_code.R
+++ b/shiny/source_code.R
@@ -21,6 +21,12 @@ library(geosphere)
 
 if (!ON.TODDS.DESKTOP)
     library(mailR) #the java 
+#JP I think our reliance on the javax object class is going to bite us
+#   We don't need a functional email address/contact form
+#   Use 'blastula' email library instead.  It only uses SSL security,
+#   but the account doesn't need more.  We can also run it on our desktops
+
+library(blastula)
 
 #-- RESOURCES --#
 source('load_resources.R')


### PR DESCRIPTION
mailR depends on Java libraries being previously installed on the
system, and while that is possible it creates an unnecessary point
of failure.  mailR used TLS security, which is the current state
of the art but isn't necessary for a feedback control on a scientific
website.  Blastula uses SSL security which is a step down but still
perfectly valid for our uses.